### PR TITLE
Rewrite addition of completion snippets for block commands from a for loop to a more functional approach

### DIFF
--- a/lsp/src/asm_server.rs
+++ b/lsp/src/asm_server.rs
@@ -366,15 +366,17 @@ impl LanguageServer for Asm {
                 "".to_owned(),
             ));
         }
-		for command in BLOCK_CONTROL_COMMANDS {
-			completion_items.push(CompletionItem {
+		completion_items.extend(BLOCK_CONTROL_COMMANDS
+			.iter()
+			.map(|command| CompletionItem {
 				label: (*command).to_string(),
 				kind: Some(CompletionItemKind::FUNCTION),
 				insert_text: Some(format!(".{} $1\n\t$0\n.end{} ; End $1", *command, *command)),
 				insert_text_format: Some(InsertTextFormat::SNIPPET),
 				..Default::default()
-			});
-		}
+			})
+		);
+
         Ok(Some(CompletionResponse::Array(completion_items)))
     }
 }

--- a/lsp/src/asm_server.rs
+++ b/lsp/src/asm_server.rs
@@ -376,7 +376,6 @@ impl LanguageServer for Asm {
 				..Default::default()
 			})
 		);
-
         Ok(Some(CompletionResponse::Array(completion_items)))
     }
 }


### PR DESCRIPTION
We discussed using `append` but that gave me issues because it requires a mutable vector I believe? `extend()` just takes an iterator which `map()` returns so I didn't have to do `collect()` at the end