### PR TITLE
Remove regex crate dependency from the opcode documentation parser in the data crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,7 +128,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "regex",
 ]
 
 [[package]]
@@ -651,35 +641,6 @@ checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2024"
 proc-macro = true
 
 [dependencies]
-regex = "1.11.1"
 quote = "1.0.40"
 proc-macro2 = "1.0.94"

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,34 +1,81 @@
+use std::io::BufRead;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 
+enum DocParserState {
+    Opcodes,
+    Description,
+}
+
 #[proc_macro]
 pub fn include_documentation(_token_stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let source_str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/65816-opcodes.md"));
-
-    let instr_re = regex::Regex::new(r#"\{([a-z]{3})}"#).unwrap();
-    let description_re = regex::Regex::new(r#"(?s)((\{[a-z]{3}}\r?\n)+)\{:}(.*?)\{\.}"#).unwrap();
-    let descriptions = description_re
-        .captures_iter(source_str)
-        .map(|c| {
-            let (_, [name, _, docs]) = c.extract();
-            (name, docs.trim())
-        });
-
+    let doc_file = std::fs::File::open(concat!(env!("CARGO_MANIFEST_DIR"), "/65816-opcodes.md")).expect("Could not open opcode documentation file.");
+    let doc_file_lines = std::io::BufReader::new(doc_file)
+        .lines()
+        .map_while(Result::ok);
     let mut opcode_setup_str: TokenStream = TokenStream::new();
 
-    for (opcodes, description) in descriptions {
-        let opcodes = instr_re
-            .captures_iter(opcodes)
-            .map(|c| c.get(1).unwrap().as_str())
-            .collect::<Vec<_>>();
-        for opcode in opcodes {
-            opcode_setup_str.extend(
-                quote! {
-                    instruction_map.insert(#opcode.to_owned(), #description.to_owned());
+    let mut state = DocParserState::Opcodes;
+    let mut curr_opcodes: Vec<String> = vec![];
+    let mut curr_description = String::new();
+    for line in doc_file_lines {
+        match state {
+            DocParserState::Opcodes => {
+                if line == "{:}" {
+                    state = DocParserState::Description;
+                    curr_description.clear();
+                    continue;
                 }
-            );
+                if let Some(opcode) = line.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
+                    curr_opcodes.push(opcode.to_string());
+                }
+            },
+            DocParserState::Description => {
+                if line == "{.}" {
+                    state = DocParserState::Opcodes;
+                    opcode_setup_str.extend(quote! {
+                        instruction_map.extend(#curr_opcodes.drain(..).map(|opcode| (opcode.to_owned(), #curr_description.to_owned())));
+                    });
+                    continue;
+                }
+                curr_description.push_str(&line);
+                curr_description.push('\n');
+            }
         }
     }
+
+
+
+
+    //
+    //
+    // let source_str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/65816-opcodes.md"));
+    //
+    // let instr_re = regex::Regex::new(r#"\{([a-z]{3})}"#).unwrap();
+    // let description_re = regex::Regex::new(r#"(?s)((\{[a-z]{3}}\r?\n)+)\{:}(.*?)\{\.}"#).unwrap();
+    // let descriptions = description_re
+    //     .captures_iter(source_str)
+    //     .map(|c| {
+    //         let (_, [name, _, docs]) = c.extract();
+    //         (name, docs.trim())
+    //     });
+    //
+    // let mut opcode_setup_str: TokenStream = TokenStream::new();
+    //
+    // for (opcodes, description) in descriptions {
+    //     let opcodes = instr_re
+    //         .captures_iter(opcodes)
+    //         .map(|c| c.get(1).unwrap().as_str())
+    //         .collect::<Vec<_>>();
+    //     for opcode in opcodes {
+    //         opcode_setup_str.extend(
+    //             quote! {
+    //                 instruction_map.insert(#opcode.to_owned(), #description.to_owned());
+    //             }
+    //         );
+    //     }
+    // }
 
     quote! {
         pub static OPCODE_DOCUMENTATION: std::sync::OnceLock<std::collections::HashMap<String, String>> = std::sync::OnceLock::new();


### PR DESCRIPTION
Doing this cut down the time of filling the `instruction_map` HashMap from around 31,560 microseconds average to about 1,200