### PR TITLE
Autocomplete instructions new doc

### DIFF
--- a/lsp/src/completion.rs
+++ b/lsp/src/completion.rs
@@ -2,7 +2,7 @@ use crate::asm_server::State;
 use crate::codespan::FileId;
 use crate::instructions;
 use crate::symbol_cache::{symbol_cache_get, SymbolType};
-use crate::documentation::{CA65_KEYWORD_COMPLETION_ITEMS, FEATURE_COMPLETION_ITEMS, MACPACK_COMPLETION_ITEMS};
+use crate::documentation::{CA65_KEYWORD_COMPLETION_ITEMS, FEATURE_COMPLETION_ITEMS, MACPACK_COMPLETION_ITEMS, OPCODE_COMPLETION_ITEMS};
 use codespan::Position;
 use tower_lsp_server::lsp_types::{CompletionItem, CompletionItemKind, CompletionItemLabelDetails};
 

--- a/lsp/src/completion.rs
+++ b/lsp/src/completion.rs
@@ -21,17 +21,7 @@ impl CompletionProvider for InstructionCompletionProvider {
         position: Position,
     ) -> Vec<CompletionItem> {
         if state.files.show_instructions(id, position) {
-            instructions::INSTRUCTION_MAP
-                .get()
-                .expect("Instructions not loaded")
-                .iter()
-                .map(|(opcode, description)| CompletionItem {
-                    label: opcode.to_lowercase().to_owned(),
-                    detail: Some(description.to_owned()),
-                    kind: Some(CompletionItemKind::KEYWORD),
-                    ..Default::default()
-                })
-                .collect()
+            OPCODE_COMPLETION_ITEMS.get().expect("Could not get OPCODE_COMPLETION_ITEMS").clone()
         } else {
             Vec::new()
         }

--- a/lsp/src/documentation.rs
+++ b/lsp/src/documentation.rs
@@ -2,13 +2,10 @@ use std::{
     collections::HashMap,
     sync::OnceLock,
 };
-use std::iter::Once;
-use std::string::ToString;
 use serde::Deserialize;
 use tower_lsp_server::lsp_types::{
     self, CompletionItem, CompletionItemKind, MarkupContent, MarkupKind, InsertTextFormat,
 };
-use tower_lsp_server::lsp_types::request::Completion;
 
 #[derive(Deserialize)]
 pub struct KeywordInfo {


### PR DESCRIPTION
This utilizes the 65xx instruction doc created in a previous ticket (for `hover`) but this time `completion`. It replaces the simpler `6502.json` used previously.

Future tickets will add a `detail` (the little label to the right of each keyword in the autocomplete dropdown) to each one like there were previously, only show instructions available to the target processor of the project, and clean up `documentation.rs` to be better structured and cleaner.

https://github.com/user-attachments/assets/b127eb31-88b5-44bf-8509-b7d6ea26f85e

