### PR TITLE
show feature and macpack doc on hover

### DIFF
--- a/lsp/src/asm_server.rs
+++ b/lsp/src/asm_server.rs
@@ -9,7 +9,7 @@ use crate::error::file_error_to_lsp;
 use crate::symbol_cache::{
     symbol_cache_get, symbol_cache_insert, symbol_cache_reset, SymbolType,
 };
-use crate::documentation::{CA65_DOCUMENTATION, INSTRUCTION_DOCUMENTATION};
+use crate::documentation::{CA65_DOCUMENTATION, FEATURE_DOCUMENTATION, INSTRUCTION_DOCUMENTATION, MACPACK_DOCUMENTATION};
 use analysis::ScopeKind;
 use parser::ParseError;
 use std::collections::HashMap;
@@ -263,6 +263,34 @@ impl LanguageServer for Asm {
                     contents: HoverContents::Markup(MarkupContent {
                         kind: MarkupKind::Markdown,
                         value: documentation,
+                    }),
+                }));
+            }
+
+            if let Some(documentation) = FEATURE_DOCUMENTATION
+                .get()
+                .unwrap()
+                .get(&word.to_lowercase())
+            {
+                return Ok(Some(Hover {
+                    range: None,
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: documentation.clone(),
+                    }),
+                }));
+            }
+
+            if let Some(documentation) = MACPACK_DOCUMENTATION
+                .get()
+                .unwrap()
+                .get(&word.to_lowercase())
+            {
+                return Ok(Some(Hover {
+                    range: None,
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: documentation.clone(),
                     }),
                 }));
             }


### PR DESCRIPTION
# What's changing
Provide hover provider for `.macpack` package names and `.feature` feature names. The documentation is already there and by the time this ticket is worked on, completion providers for both (using the same documentation) should be in `main`.

# Motivation for change
It makes sense to have the same documentation handy when the user hovers over a feature or macpack name, as when autocompleting.

# Background/Notes
