### PR TITLE
bug: file.line_tokens() does not seem to function properly depending on where the cursor is

### DIFF
--- a/lsp/src/codespan.rs
+++ b/lsp/src/codespan.rs
@@ -107,7 +107,7 @@ impl Files {
 
         tokens
             .iter()
-            .filter(|token| token.span.start >= line_span.start && token.span.end < line_span.end)
+            .filter(|token| token.span.start >= line_span.start && token.span.end <= line_span.end)
             .cloned()
             .collect::<Vec<Token>>()
     }

--- a/lsp/src/completion.rs
+++ b/lsp/src/completion.rs
@@ -5,6 +5,7 @@ use crate::symbol_cache::{symbol_cache_get, SymbolType};
 use crate::documentation::{CA65_KEYWORD_COMPLETION_ITEMS, FEATURE_COMPLETION_ITEMS, MACPACK_COMPLETION_ITEMS, INSTRUCTION_COMPLETION_ITEMS};
 use codespan::Position;
 use tower_lsp_server::lsp_types::{CompletionItem, CompletionItemKind, CompletionItemLabelDetails};
+use parser::TokenType;
 
 pub trait CompletionProvider {
     fn completions_for(&self, state: &State, id: FileId, position: Position)
@@ -91,7 +92,12 @@ impl CompletionProvider for MacpackCompletionProvider {
         id: FileId,
         position: Position
     ) -> Vec<CompletionItem> {
-        if state.files.line_tokens(id, position).last().is_some_and(|tok| tok.lexeme == ".macpack") {
+        if state.files.line_tokens(id, position)
+            .iter()
+            .filter(|tok| tok.token_type != TokenType::EOL)
+            .nth_back(1)
+            .is_some_and(|tok| tok.lexeme == ".macpack"
+            ) {
             MACPACK_COMPLETION_ITEMS.get().expect("Could not get MACPACK_COMPLETION_ITEMS in completion provider").clone()
         } else {
             Vec::new()
@@ -107,7 +113,12 @@ impl CompletionProvider for FeatureCompletionProvider {
         id: FileId,
         position: Position
     ) -> Vec<CompletionItem> {
-        if state.files.line_tokens(id, position).last().is_some_and(|tok| tok.lexeme == ".feature") {
+        if state.files.line_tokens(id, position)
+            .iter()
+            .filter(|tok| tok.token_type != TokenType::EOL)
+            .nth_back(1)
+            .is_some_and(|tok| tok.lexeme == ".feature"
+        ) {
             FEATURE_COMPLETION_ITEMS.get().expect("Could not get FEATURE_COMPLETION_ITEMS in completion provider").clone()
         } else {
             Vec::new()

--- a/lsp/src/completion.rs
+++ b/lsp/src/completion.rs
@@ -97,7 +97,7 @@ impl CompletionProvider for MacpackCompletionProvider {
             .filter(|tok| tok.token_type != TokenType::EOL)
             .nth_back(1)
             .is_some_and(|tok| tok.lexeme == ".macpack"
-            ) {
+        ) {
             MACPACK_COMPLETION_ITEMS.get().expect("Could not get MACPACK_COMPLETION_ITEMS in completion provider").clone()
         } else {
             Vec::new()


### PR DESCRIPTION
The change in this ticket solves the following edge case:
- my file ends on position 251.
- I'm currently typing "atari"
- the "i" in "atari" is also on position 251. It is the last character of the file, there is no newline to close the file.
- "atari" should be recognized as a token on the current line, just as it would be on any previous line when followed by an EOL token.

This is the reasoning for changing `<` to `<=`.