### PR TITLE
Parser add if parsing

### DIFF
--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -15,7 +15,7 @@ pub enum ScopeKind {
     Label,
     Macro,
     Constant,
-    Parameter,
+    Parameter
 }
 
 pub struct Scope {

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -15,7 +15,7 @@ pub enum ScopeKind {
     Label,
     Macro,
     Constant,
-    Parameter
+    Parameter,
 }
 
 pub struct Scope {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -133,18 +133,9 @@ pub struct Instruction {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IfKind {
-    Regular(Expression),
-    Const(Expression),
-    Blank(Vec<Token>),
-    NotBlank(Vec<Token>),
-    Defined(Vec<Token>),
-    NotDefined(Vec<Token>),
-    Referenced(Vec<Token>),
-    NotReferenced(Vec<Token>),
-    P02,
-    P4510,
-    P816,
-    PC02,
+    WithExpression(Expression),
+    WithTokens(Vec<Token>),
+    NoParams,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -439,8 +430,7 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".if" | ".ifconst" | ".ifblank" | ".ifnblank" | ".ifdef" | ".ifndef" | ".ifref"
-                | ".ifnref" | ".ifp02" | ".ifp4510" | ".ifp816" | ".ifpC02" => {
+                ".if" | ".ifconst" | ".ifblank" | ".ifnblank" | ".ifdef" | ".ifndef" | ".ifref" | ".ifnref" | ".ifp02" | ".ifp4510" | ".ifp816" | ".ifpC02" => {
                     Ok(Some(self.parse_if()?))
                 }
                 // Ignored for now
@@ -459,18 +449,9 @@ impl<'a> Parser<'a> {
         let start = self.mark_start();
         let if_token = self.last();
         let if_kind = match if_token.lexeme.as_str() {
-            ".if" => IfKind::Regular(self.parse_expression()?),
-            ".ifconst" => IfKind::Const(self.parse_expression()?),
-            ".ifblank" => IfKind::Blank(self.parse_parameters_tokens()?),
-            ".ifnblank" => IfKind::NotBlank(self.parse_parameters_tokens()?),
-            ".ifdef" => IfKind::Defined(self.parse_parameters_tokens()?),
-            ".ifndef" => IfKind::NotDefined(self.parse_parameters_tokens()?),
-            ".ifref" => IfKind::Referenced(self.parse_parameters_tokens()?),
-            ".ifnref" => IfKind::NotReferenced(self.parse_parameters_tokens()?),
-            ".ifp02" => IfKind::P02,
-            ".ifp4510" => IfKind::P4510,
-            ".ifp816" => IfKind::P816,
-            ".ifpC02" => IfKind::PC02,
+            ".if" | ".ifconst" => IfKind::WithExpression(self.parse_expression()?),
+            ".ifblank" | ".ifnblank" | ".ifdef" | ".ifndef" | ".ifref" | ".ifnref" => IfKind::WithTokens(self.parse_parameters_tokens()?),
+            ".ifp02" | ".ifp4510" | ".ifp816" | ".ifpC02" => IfKind::NoParams,
             _ => {
                 unreachable!(".if strings in parse_if() do not match .if strings in parse_macro()")
             }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -450,16 +450,20 @@ impl<'a> Parser<'a> {
 
     fn parse_if(&mut self) -> Result<Line> {
         let start = self.mark_start();
-        let condition = self.parse_expression()?;
-        let end = self.mark_end();
-        self.consume_newline()?;
+        let if_token = self.last();
+        let if_kind = match if_token.lexeme.as_str() {
+            ".if" => IfKind::Regular(self.parse_expression()?),
+            ".ifconst" => IfKind::Const(self.parse_expression()?),
+            ".ifblank" => IfKind::Blank(self.parse_parameters()?),
+            _ => IfKind::P02,
+        };
 
-        while !self.tokens.at_end() {
-            return Ok(Line {
-                kind: LineKind::If(condition),
-                span: Span::new(start, end),
-            });
-        }
+        // while !self.tokens.at_end() {
+        //     return Ok(Line {
+        //         kind: LineKind::If(condition),
+        //         span: Span::new(start, end),
+        //     });
+        // }
 
         Err(ParseError::Expected {
             received: self.peek()?,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -377,7 +377,7 @@ impl<'a> Parser<'a> {
                     return Ok(Some(Statement {
                         kind: StatementKind::Scope(
                             ident,
-                            commands
+                            commands,
                         ),
                         span: Span::new(start, end),
                     }));
@@ -396,7 +396,7 @@ impl<'a> Parser<'a> {
                     return Ok(Some(Statement{
                         kind: StatementKind::Repeat(max, iter, commands),
                         span: Span::new(start, end),
-                    }));
+                    }))
                 }
                 ".res"|".tag" => {
                     let right = self.parse_expression()?;
@@ -447,7 +447,7 @@ impl<'a> Parser<'a> {
                 ".index" | ".mem" | ".align" | ".addr" => {
                     self.parse_parameters()?;
                     Ok(None)
-                },
+                }, 
                 _ => Err(ParseError::UnexpectedToken(mac)),
             };
         }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -132,6 +132,22 @@ pub struct Instruction {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum IfKind {
+    Regular(Expression),
+    Blank(Vec<Token>),
+    NotBlank(Vec<Token>),
+    Defined(Vec<Token>),
+    NotDefined(Vec<Token>),
+    Referenced(Vec<Token>),
+    NotReferenced(Vec<Token>),
+    Const(Expression),
+    P02,
+    P4510,
+    P816,
+    PC02,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum StatementKind {
     ConstantAssign(ConstantAssign),
     Include(Token),
@@ -156,7 +172,7 @@ pub enum StatementKind {
     Global(Vec<Token>, bool), // Identifier, is zero page?
     Export(Vec<Token>, bool),
     Ascii(Token),
-    If(Expression),
+    If(IfKind),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -478,11 +478,11 @@ impl<'a> Parser<'a> {
         while !self.tokens.at_end() {
             if check_token!(self.tokens, TokenType::Macro) {
                 let m = self.peek()?.lexeme;
-                if m == ".endmacro" {
+                if m == ".endif" {
                     self.tokens.advance();
                     let end = self.mark_end();
                     return Ok(Statement {
-                        kind: StatementKind::MacroDefinition(ident, parameters, commands),
+                        kind: StatementKind::If(if_kind),
                         span: Span::new(start, end),
                     });
                 }
@@ -491,18 +491,6 @@ impl<'a> Parser<'a> {
                 commands.push(line);
             }
         }
-
-        Err(ParseError::Expected {
-            received: self.peek()?,
-            expected: TokenType::Macro,
-        })
-
-        // while !self.tokens.at_end() {
-        //     return Ok(Line {
-        //         kind: LineKind::If(condition),
-        //         span: Span::new(start, end),
-        //     });
-        // }
 
         Err(ParseError::Expected {
             received: self.peek()?,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -461,14 +461,26 @@ impl<'a> Parser<'a> {
         let mut commands: Vec<Statement> = vec![];
         while !self.tokens.at_end() {
             if check_token!(self.tokens, TokenType::Macro) {
-                let m = self.peek()?.lexeme;
-                if m == ".endif" {
-                    self.tokens.advance();
-                    let end = self.mark_end();
-                    return Ok(Statement {
-                        kind: StatementKind::If(if_kind),
-                        span: Span::new(start, end),
-                    });
+                let tok_lexeme = self.peek()?.lexeme;
+                match tok_lexeme.as_str() {
+                    ".elseif" => {
+                        self.tokens.advance();
+                        self.parse_expression()?;
+                        self.consume_newline()?;
+                    }
+                    ".else" => {
+                        self.tokens.advance();
+                        self.consume_newline()?;
+                    }
+                    ".endif" => {
+                        self.tokens.advance();
+                        let end = self.mark_end();
+                        return Ok(Statement {
+                            kind: StatementKind::If(if_kind),
+                            span: Span::new(start, end),
+                        });
+                    }
+                    _ => ()
                 }
             }
             if let Some(line) = self.parse_line()? {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -448,7 +448,7 @@ impl<'a> Parser<'a> {
         Ok(Some(self.parse_assignment()?))
     }
 
-    fn parse_if(&mut self) -> Result<Line> {
+    fn parse_if(&mut self) -> Result<Statement> {
         let start = self.mark_start();
         let if_token = self.last();
         let if_kind = match if_token.lexeme.as_str() {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -235,7 +235,7 @@ impl<'a> Parser<'a> {
 
             return operation;
         }
-
+        
         Err(ParseError::UnexpectedToken(self.tokens.peek().unwrap()))
     }
 
@@ -246,7 +246,7 @@ impl<'a> Parser<'a> {
             let ident = &mac.lexeme;
             let macro_matcher = ident.to_lowercase();
             return match macro_matcher.as_str() {
-                ".global" | ".globalzp" => {
+                ".global"|".globalzp" => {
                     let zp = macro_matcher == ".globalzp";
                     let mut idents = vec![];
                     idents.push(self.consume_token(TokenType::Identifier)?);
@@ -260,7 +260,7 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".export" | ".exportzp" => {
+                ".export"|".exportzp" => {
                     let zp = macro_matcher == ".exportzp";
                     let mut idents = vec![];
                     idents.push(self.consume_token(TokenType::Identifier)?);
@@ -329,7 +329,7 @@ impl<'a> Parser<'a> {
                     let address = self.consume_token(TokenType::Number)?;
                     let end = self.mark_end();
                     self.consume_newline()?;
-
+                    
                     Ok(Some(Statement {
                         kind: StatementKind::Org(address.lexeme.clone()),
                         span: Span::new(start, end),
@@ -353,7 +353,7 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".macro" | ".mac" => Ok(Some(self.parse_macro_def()?)),
+                ".macro"|".mac" => Ok(Some(self.parse_macro_def()?)),
                 ".proc" => {
                     self.consume_token(TokenType::Identifier)?;
                     let ident = self.last();
@@ -375,7 +375,10 @@ impl<'a> Parser<'a> {
                     let commands = self.parse_statement_block(".endscope")?;
                     let end = self.mark_end();
                     return Ok(Some(Statement {
-                        kind: StatementKind::Scope(ident, commands),
+                        kind: StatementKind::Scope(
+                            ident,
+                            commands
+                        ),
                         span: Span::new(start, end),
                     }));
                 }
@@ -390,12 +393,12 @@ impl<'a> Parser<'a> {
                     self.consume_newline()?;
                     let commands = self.parse_statement_block(".endrepeat")?;
                     let end = self.mark_end();
-                    return Ok(Some(Statement {
+                    return Ok(Some(Statement{
                         kind: StatementKind::Repeat(max, iter, commands),
                         span: Span::new(start, end),
                     }));
                 }
-                ".res" | ".tag" => {
+                ".res"|".tag" => {
                     let right = self.parse_expression()?;
                     let end = self.mark_end();
                     self.consume_newline()?;
@@ -415,7 +418,7 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".db" | ".dw" | ".byte" | ".word" | ".lobytes" => {
+                ".db"|".dw"|".byte"|".word"|".lobytes" => {
                     let parameters = self.parse_parameters()?;
                     let end = self.mark_end();
                     self.consume_newline()?;
@@ -444,7 +447,7 @@ impl<'a> Parser<'a> {
                 ".index" | ".mem" | ".align" | ".addr" => {
                     self.parse_parameters()?;
                     Ok(None)
-                }
+                },
                 _ => Err(ParseError::UnexpectedToken(mac)),
             };
         }
@@ -814,7 +817,7 @@ impl<'a> Parser<'a> {
             return Ok(Expression {
                 kind: ExpressionKind::Bank(Box::from(expr)),
                 span: Span::new(start, end),
-            });
+            })
         }
         if match_token!(self.tokens, TokenType::SizeOf) {
             self.consume_token(TokenType::LeftParen)?;
@@ -825,7 +828,7 @@ impl<'a> Parser<'a> {
             return Ok(Expression {
                 kind: ExpressionKind::SizeOf(Box::from(expr)),
                 span: Span::new(start, end),
-            });
+            })
         }
         if match_token!(self.tokens, TokenType::Caret) {
             let right = self.parse_factor()?;


### PR DESCRIPTION
# What's changing
Adding parsing logic for all variants of ca65's `.if`

# Motivation for change
Parsing logic is incomplete

# Background/Notes
- `.if` (requires expression)
- `.ifblank` (requires parameters)
- `.ifnblank` (requires parameters)
- `.ifdef` (requires parameters)
- `.ifndef` (requires parameters)
- `.ifref` (requires parameters)
- `.ifnref` (requires parameters)
- `.ifconst` (requires expression)
- `.ifp02`
- `.ifp4510`
- `.ifp816`
- `.ifpc02`