### PR TITLE
Parser add enum parsing

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -226,7 +226,7 @@ impl<'a> Parser<'a> {
 
             return operation;
         }
-
+        
         Err(ParseError::UnexpectedToken(self.tokens.peek().unwrap()))
     }
 
@@ -237,7 +237,7 @@ impl<'a> Parser<'a> {
             let ident = &mac.lexeme;
             let macro_matcher = ident.to_lowercase();
             return match macro_matcher.as_str() {
-                ".global" | ".globalzp" => {
+                ".global"|".globalzp" => {
                     let zp = macro_matcher == ".globalzp";
                     let mut idents = vec![];
                     idents.push(self.consume_token(TokenType::Identifier)?);
@@ -251,7 +251,7 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".export" | ".exportzp" => {
+                ".export"|".exportzp" => {
                     let zp = macro_matcher == ".exportzp";
                     let mut idents = vec![];
                     idents.push(self.consume_token(TokenType::Identifier)?);
@@ -320,7 +320,7 @@ impl<'a> Parser<'a> {
                     let address = self.consume_token(TokenType::Number)?;
                     let end = self.mark_end();
                     self.consume_newline()?;
-
+                    
                     Ok(Some(Statement {
                         kind: StatementKind::Org(address.lexeme.clone()),
                         span: Span::new(start, end),
@@ -344,7 +344,7 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".macro" | ".mac" => Ok(Some(self.parse_macro_def()?)),
+                ".macro"|".mac" => Ok(Some(self.parse_macro_def()?)),
                 ".enum" => Ok(Some(self.parse_enum()?)),
                 ".proc" => {
                     self.consume_token(TokenType::Identifier)?;
@@ -367,7 +367,10 @@ impl<'a> Parser<'a> {
                     let commands = self.parse_statement_block(".endscope")?;
                     let end = self.mark_end();
                     return Ok(Some(Statement {
-                        kind: StatementKind::Scope(ident, commands),
+                        kind: StatementKind::Scope(
+                            ident,
+                            commands,
+                        ),
                         span: Span::new(start, end),
                     }));
                 }
@@ -382,12 +385,12 @@ impl<'a> Parser<'a> {
                     self.consume_newline()?;
                     let commands = self.parse_statement_block(".endrepeat")?;
                     let end = self.mark_end();
-                    return Ok(Some(Statement {
+                    return Ok(Some(Statement{
                         kind: StatementKind::Repeat(max, iter, commands),
                         span: Span::new(start, end),
-                    }));
+                    }))
                 }
-                ".res" | ".tag" => {
+                ".res"|".tag" => {
                     let right = self.parse_expression()?;
                     let end = self.mark_end();
                     self.consume_newline()?;
@@ -407,7 +410,7 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".db" | ".dw" | ".byte" | ".word" | ".lobytes" => {
+                ".db"|".dw"|".byte"|".word"|".lobytes" => {
                     let parameters = self.parse_parameters()?;
                     let end = self.mark_end();
                     self.consume_newline()?;
@@ -428,15 +431,14 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".if" | ".ifconst" | ".ifblank" | ".ifnblank" | ".ifdef" | ".ifndef" | ".ifref"
-                | ".ifnref" | ".ifp02" | ".ifp4510" | ".ifp816" | ".ifpC02" => {
+                ".if" | ".ifconst" | ".ifblank" | ".ifnblank" | ".ifdef" | ".ifndef" | ".ifref" | ".ifnref" | ".ifp02" | ".ifp4510" | ".ifp816" | ".ifpC02" => {
                     Ok(Some(self.parse_if()?))
                 }
                 // Ignored for now
                 ".index" | ".mem" | ".align" | ".addr" => {
                     self.parse_parameters()?;
                     Ok(None)
-                }
+                }, 
                 _ => Err(ParseError::UnexpectedToken(mac)),
             };
         }
@@ -449,9 +451,7 @@ impl<'a> Parser<'a> {
         let if_token = self.last();
         let if_kind = match if_token.lexeme.as_str() {
             ".if" | ".ifconst" => IfKind::WithExpression(self.parse_expression()?),
-            ".ifblank" | ".ifnblank" | ".ifdef" | ".ifndef" | ".ifref" | ".ifnref" => {
-                IfKind::WithTokens(self.parse_parameters_tokens()?)
-            }
+            ".ifblank" | ".ifnblank" | ".ifdef" | ".ifndef" | ".ifref" | ".ifnref" => IfKind::WithTokens(self.parse_parameters_tokens()?),
             ".ifp02" | ".ifp4510" | ".ifp816" | ".ifpC02" => IfKind::NoParams,
             _ => {
                 unreachable!(".if strings in parse_if() do not match .if strings in parse_macro()")
@@ -481,7 +481,7 @@ impl<'a> Parser<'a> {
                             span: Span::new(start, end),
                         });
                     }
-                    _ => (),
+                    _ => ()
                 }
             }
             if let Some(line) = self.parse_line()? {
@@ -849,7 +849,7 @@ impl<'a> Parser<'a> {
             return Ok(Expression {
                 kind: ExpressionKind::Bank(Box::from(expr)),
                 span: Span::new(start, end),
-            });
+            })
         }
         if match_token!(self.tokens, TokenType::SizeOf) {
             self.consume_token(TokenType::LeftParen)?;
@@ -860,7 +860,7 @@ impl<'a> Parser<'a> {
             return Ok(Expression {
                 kind: ExpressionKind::SizeOf(Box::from(expr)),
                 span: Span::new(start, end),
-            });
+            })
         }
         if match_token!(self.tokens, TokenType::Caret) {
             let right = self.parse_factor()?;


### PR DESCRIPTION
# What's changing
Add `.enum` handling to `parse_macro()` in `parser.s`

# Motivation for change
There are many, many more ca65 keywords (also referred to as "macros" or in `ca65.html`, "control commands") to add to `parse_macro()`

# Background/Notes
