### PR TITLE
Parser add remaining segment macros

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -405,10 +405,10 @@ impl<'a> Parser<'a> {
                     let end = self.mark_end();
                     self.consume_newline()?;
 
-                    let segment_name = &macro_matcher[1..];
+                    let segment_name = macro_matcher[1..].to_string();
 
                     Ok(Some(Statement {
-                        kind: StatementKind::Segment(segment_name.into()),
+                        kind: StatementKind::Segment(segment_name),
                         span: Span::new(start, end),
                     }))
                 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -401,12 +401,14 @@ impl<'a> Parser<'a> {
                         span: Span::new(start, end),
                     }))
                 }
-                ".zeropage" => {
+                ".zeropage" | ".code" | ".bss" | ".data" | ".rodata" => {
                     let end = self.mark_end();
                     self.consume_newline()?;
 
+                    let segment_name = &macro_matcher[1..];
+
                     Ok(Some(Statement {
-                        kind: StatementKind::Segment("zeropage".to_string()),
+                        kind: StatementKind::Segment(segment_name.into()),
                         span: Span::new(start, end),
                     }))
                 }


### PR DESCRIPTION
# What's changing
Adding `.code`, `.bss`, `.rodata` and `.data` to `parse_macro()`

# Motivation for change
Plenty of control commands to add to `parser.rs` still

# Background/Notes