### PR TITLE
Parser add unnamed labels

### DIFF
--- a/lsp/src/asm_server.rs
+++ b/lsp/src/asm_server.rs
@@ -13,7 +13,6 @@ use crate::symbol_cache::{symbol_cache_get, symbol_cache_insert, symbol_cache_re
 use analysis::{Scope, ScopeAnalyzer, Symbol};
 use codespan::Span;
 use parser::ParseError;
-use std::any::Any;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Output;

--- a/lsp/src/asm_server.rs
+++ b/lsp/src/asm_server.rs
@@ -13,6 +13,7 @@ use crate::symbol_cache::{symbol_cache_get, symbol_cache_insert, symbol_cache_re
 use analysis::{Scope, ScopeAnalyzer, Symbol};
 use codespan::Span;
 use parser::ParseError;
+use std::any::Any;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Output;

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -232,6 +232,7 @@ impl<'a> Parser<'a> {
                 TokenType::Macro => self.parse_macro(),
                 TokenType::Identifier => Ok(Some(self.parse_assignment()?)),
                 TokenType::Instruction => Ok(Some(self.parse_instruction()?)),
+                TokenType::Colon => self.parse_unnamed_label(),
                 TokenType::EOL => {
                     self.tokens.advance();
                     Ok(None)
@@ -656,6 +657,16 @@ impl<'a> Parser<'a> {
             kind: StatementKind::Label(name),
             span: Span::new(start, end),
         })
+    }
+
+    fn parse_unnamed_label(&mut self) -> Result<Option<Statement>> {
+        let start = self.mark_start();
+        self.consume_token(TokenType::Colon)?;
+        let end = self.mark_end();
+        Ok(Some(Statement {
+            kind: StatementKind::UnnamedLabel,
+            span: Span::new(start, end),
+        }))
     }
 
     fn parse_macro_invocation(&mut self) -> Result<Statement> {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -105,6 +105,7 @@ pub enum ExpressionKind {
     Immediate(Box<Expression>),
     Unary(TokenType, Box<Expression>),
     Literal(String),
+    UnnamedLabel(i8),
     Group(Box<Expression>),
     UnaryPositive(Box<Expression>),
     Math(TokenType, Box<Expression>, Box<Expression>),

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -919,7 +919,7 @@ impl<'a> Parser<'a> {
         {
             return self.parse_identifier();
         }
-        if check_token!(self.tokens, TokenType::Colon) {
+        if check_token!(self.tokens, TokenType::UnnamedLabelReference) {
             return self.parse_unnamed_label_reference();
         }
         if match_token!(self.tokens, TokenType::LeftParen) {
@@ -1003,37 +1003,15 @@ impl<'a> Parser<'a> {
 
     fn parse_unnamed_label_reference(&mut self) -> Result<Expression> {
         let start = self.mark_start();
-        let mut distance: i8 = 0;
 
-        self.consume_token(TokenType::Colon)?;
-        let next_tok = self.peek()?;
-        match next_tok.token_type {
-            TokenType::Plus => {
-                while self.consume_token(TokenType::Plus).is_ok() {
-                    distance += 1;
-                }
-                self.consume_newline();
-            }
-            TokenType::GreaterThan => {
-                while self.consume_token(TokenType::GreaterThan).is_ok() {
-                    distance += 1;
-                }
-                self.consume_newline();
-            }
-            TokenType::Minus => {
-                while self.consume_token(TokenType::Minus).is_ok() {
-                    distance -= 1;
-                }
-                self.consume_newline();
-            }
-            TokenType::LessThan => {
-                while self.consume_token(TokenType::LessThan).is_ok() {
-                    distance -= 1;
-                }
-                self.consume_newline();
-            }
-            _ => (),
-        }
+        self.consume_token(TokenType::UnnamedLabelReference)?;
+
+        let distance_abs = self.last().lexeme.trim_start_matches(':').len() as i8;
+        let distance = match self.last().lexeme.chars().nth(1) {
+            Some('+') | Some('>') => distance_abs,
+            Some('-') | Some('<') => -distance_abs,
+            _ => 0,
+        };
 
         let end = self.mark_end();
 


### PR DESCRIPTION
# What's changing
Currently, the parser throws an error when it encounters an unnamed label--either a declaration (`:`) or a reference (`lda :-`). This issue adds support for both.

# Motivation for change
Unnamed labels are a commonly used feature not just in ca65 but many assemblers

# Background/Notes
