### PR TITLE
Account for additional embedded control commands in structs

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -698,7 +698,13 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 let ident = self.consume_token(TokenType::Identifier)?;
-                let _data_type = self.consume_token(TokenType::Macro)?; // TODO: add data type
+                let _data_type = self.consume_token(TokenType::Macro)?; // TODO: add data t ype
+                if check_token!(self.tokens, TokenType::Identifier) {
+                   self.consume_token(TokenType::Identifier)?;
+                }
+                if check_token!(self.tokens, TokenType::Number) {
+                   self.consume_token(TokenType::Number)?;
+                }
                 members.push(StructMember::Field(ident));
                 self.consume_newline()?;
             }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -698,13 +698,9 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 let ident = self.consume_token(TokenType::Identifier)?;
-                let _data_type = self.consume_token(TokenType::Macro)?; // TODO: add data t ype
-                if check_token!(self.tokens, TokenType::Identifier) {
-                   self.consume_token(TokenType::Identifier)?;
-                }
-                if check_token!(self.tokens, TokenType::Number) {
-                   self.consume_token(TokenType::Number)?;
-                }
+                let _data_type = self.consume_token(TokenType::Macro)?; // TODO: add data type
+                match_token!(self.tokens, TokenType::Identifier);
+                match_token!(self.tokens, TokenType::Number);
                 members.push(StructMember::Field(ident));
                 self.consume_newline()?;
             }


### PR DESCRIPTION
Currently when we parse structs, we allow for parameterless control commands like `.word` or `.byte`. But it's also common to use slightly more complex commands like `.tag` or `.res` that are followed by an identifier or a number.

This patch crudely allows for these general shapes by allowing optional identifiers or numbers following a macro token type.