### PR TITLE
add new magic symbol to snippets to mean 'keyword without leading period'

### DIFF
--- a/data/snippets.json
+++ b/data/snippets.json
@@ -7,7 +7,7 @@
   "word_with_string_arg": "% \"$1\"",
   "word_with_char_arg": "% '$1'",
   "word_with_two_args": "% $1, $2",
-  "closure": "% $1\n\t$0\n.end%",
+  "closure": "% $1\n\t$0\n.end@",
   "if_with_param": "% $1\n\t$0\n.endif",
   "if_no_param": "%\n\t$0\n.endif",
   "else": "%\n\t$0",

--- a/lsp/src/documentation.rs
+++ b/lsp/src/documentation.rs
@@ -136,7 +136,8 @@ fn get_completion_item_vec_from_multi_key_single_doc(
                     snippets
                         .get(&keyword_info.snippet_type)
                         .expect("Could not get snippet type for keyword")
-                        .replace("%", keyword),
+                        .replace("%", keyword)
+                        .replace("@", &keyword[1..]),
                 ),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 ..Default::default()
@@ -164,7 +165,8 @@ fn get_completion_item_vec_from_multi_key_single_doc(
                     snippets
                         .get(keyword_info.snippet_type.as_str())
                         .expect("Could not get snippet type for keyword")
-                        .replace("%", alias),
+                        .replace("%", alias)
+                        .replace("@", &alias[1..]),
                 ),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 ..Default::default()


### PR DESCRIPTION
**Describe the bug**
Following #39, an extra period is appearing in `.end...` statements (e.g. `.end.macro`) because I added the period as part of the autocomplete words. I still think it's best to keep the period a part of the keyword being autocompleted (e.g. `.macro` instead of `macro`), so this issue circumvents that a different way.

**To Reproduce**
1. type "mac"
2. select the "`.macro`" autocomplete
3. verify the end statement completes as `.end.macro` (the parser should yell at you for this line)

**Expected behavior**
End statements should look like e.g. `.endmacro` with only the first period

**Screenshots**
![Image](https://github.com/user-attachments/assets/7e22115e-43d1-4cbe-a4c6-91b67a279fd0)

**Environment**
- os: Windows 11
- editor: helix
- date created: June 7, 2025
