### PR TITLE
Do not add extra dot to ca65 keyword completions

### DIFF
--- a/lsp/src/completion.rs
+++ b/lsp/src/completion.rs
@@ -134,6 +134,17 @@ impl CompletionProvider for Ca65KeywordCompletionProvider {
             .get_word_at_position(position)
             .expect("Could not get word at position in completion provider");
 
+        let insert_range = Range {
+            start: tower_lsp_server::lsp_types::Position {
+                line: position.line as u32,
+                character: (position.character - curr_word.len()) as u32
+            },
+            end: tower_lsp_server::lsp_types::Position {
+                line: position.line as u32,
+                character: position.character as u32
+            },
+        };
+
         COMPLETION_ITEMS_COLLECTION
             .get()
             .expect("Could not get completion items collection for ca65 keywords")
@@ -144,40 +155,9 @@ impl CompletionProvider for Ca65KeywordCompletionProvider {
                 let mut new_item = item.clone();
                 new_item.text_edit = Some(CompletionTextEdit::InsertAndReplace(InsertReplaceEdit {
                     new_text: item.insert_text.as_ref().expect("ca65 keyword completion item did not have insert_text").clone(),
-                    insert: Range {
-                        start: tower_lsp_server::lsp_types::Position {
-                            line: position.line as u32,
-                            character: (position.character - curr_word.len()) as u32
-                        },
-                        end: tower_lsp_server::lsp_types::Position {
-                            line: position.line as u32,
-                            character: position.character as u32
-                        },
-                    },
-                    replace: Range {
-                        start: tower_lsp_server::lsp_types::Position {
-                            line: position.line as u32,
-                            character: position.character as u32
-                        },
-                        end: tower_lsp_server::lsp_types::Position {
-                            line: position.line as u32,
-                            character: position.character as u32
-                        },
-                    },
+                    insert: insert_range,
+                    replace: insert_range,
                 }));
-                // new_item.text_edit = Some(CompletionTextEdit {
-                //     range: Range {
-                //         start: tower_lsp_server::lsp_types::Position {
-                //             line: position.line as u32,
-                //             character: position.character as u32,
-                //         },
-                //         end: tower_lsp_server::lsp_types::Position {
-                //             line: position.line as u32,
-                //             character: position.character as u32,
-                //         },
-                //     },
-                //     new_text: item.label,
-                // });
                 new_item
             })
             .collect()


### PR DESCRIPTION
I was able to accomplish this by implementing the `CompletionItem`'s `textEdit` member; essentially taking the range which the autocompleted word will replace into our own hands. (I want to get Simon's input on whether this is how we want to go about it.)

I tested this in Helix, Zed, Neovim and VS Code (with Simon's latest changes to `ca65-code`) and it works in all of them.

https://github.com/user-attachments/assets/a1ce3007-bc94-48e1-a6d9-7bb2c90c3ee0

---

# What's changing
When autocompleting a ca65 keyword, do not add the period (.) if the user has already typed one. Current functionality: I want to open a macro block so I type `.m`, see the autocomplete for `macro`, select it, but then the line becomes `..macro` which is annoying and unwanted. This is because the completion provider takes the _actual keyword_, which is `macro`, and _prepends a period,_ effectively not levereging the client's logic for "completing the word", since (.) isn't _part_ of the word

# Motivation for change
Improve the quality of the autocomplete experience