### PR TITLE
ignore error result from client.inlay_hint_refresh()

### DIFF
--- a/lsp/src/asm_server.rs
+++ b/lsp/src/asm_server.rs
@@ -21,13 +21,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tower_lsp_server::lsp_types::{
-    CodeActionParams, CodeActionProviderCapability, CodeActionResponse, CompletionItem,
-    CompletionOptions, CompletionParams, CompletionResponse, Diagnostic, DiagnosticSeverity,
-    DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams, DocumentSymbol,
-    DocumentSymbolParams, DocumentSymbolResponse, FileOperationRegistrationOptions, FoldingRange,
-    FoldingRangeParams, FoldingRangeProviderCapability, HoverContents, HoverProviderCapability,
-    InitializedParams, InlayHint, InlayHintLabel, InlayHintParams, LocationLink, MarkupContent,
-    MarkupKind, MessageType, OneOf, Registration, SymbolKind,
+    ClientCapabilities, CodeActionParams, CodeActionProviderCapability, CodeActionResponse,
+    CompletionItem, CompletionOptions, CompletionParams, CompletionResponse, Diagnostic,
+    DiagnosticSeverity, DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams,
+    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FileOperationRegistrationOptions,
+    FoldingRange, FoldingRangeParams, FoldingRangeProviderCapability, HoverContents,
+    HoverProviderCapability, InitializedParams, InlayHint, InlayHintLabel, InlayHintParams,
+    LocationLink, MarkupContent, MarkupKind, MessageType, OneOf, Registration, SymbolKind,
     WorkspaceFileOperationsServerCapabilities, WorkspaceFoldersServerCapabilities,
     WorkspaceServerCapabilities,
 };
@@ -58,6 +58,7 @@ impl Asm {
             files: Files::new(),
             workspace_folder: None,
             client: client.clone(),
+            client_capabilities: ClientCapabilities::default(),
         }));
         Asm {
             client,
@@ -151,6 +152,8 @@ impl LanguageServer for Asm {
                 state.workspace_folder = Some(workspace_folders.first().unwrap().clone().uri)
             }
         }
+
+        state.client_capabilities = params.capabilities.clone();
 
         Ok(InitializeResult {
             server_info: None,

--- a/lsp/src/index_engine.rs
+++ b/lsp/src/index_engine.rs
@@ -5,7 +5,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tower_lsp_server::lsp_types::request::WorkDoneProgressCreate;
-use tower_lsp_server::lsp_types::{ProgressToken, Uri, WorkDoneProgressCreateParams};
+use tower_lsp_server::lsp_types::{
+    InlayHintWorkspaceClientCapabilities, ProgressToken, Uri, WorkDoneProgressCreateParams,
+    WorkspaceClientCapabilities,
+};
 use tower_lsp_server::Client;
 use uuid::Uuid;
 
@@ -78,16 +81,16 @@ impl IndexEngine {
             state.publish_diagnostics(*id, diags).await;
         }
 
-        if state
-            .client_capabilities
-            .workspace
-            .as_ref()
-            .is_some_and(|w| {
-                w.inlay_hint
-                    .as_ref()
-                    .is_some_and(|i| i.refresh_support.is_some_and(|r| r))
+        if matches!(
+            &state.client_capabilities.workspace,
+            Some(WorkspaceClientCapabilities {
+                inlay_hint: Some(InlayHintWorkspaceClientCapabilities {
+                    refresh_support: Some(true),
+                    ..
+                }),
+                ..
             })
-        {
+        ) {
             state.client.inlay_hint_refresh().await.unwrap();
         }
 

--- a/lsp/src/index_engine.rs
+++ b/lsp/src/index_engine.rs
@@ -28,7 +28,10 @@ impl IndexEngine {
             .await
             .unwrap();
 
-        let directory = url::Url::parse(root_uri.as_str()).unwrap().to_file_path().unwrap();
+        let directory = url::Url::parse(root_uri.as_str())
+            .unwrap()
+            .to_file_path()
+            .unwrap();
         let mut sources = vec![];
         let progress = client
             .progress(token, "Indexing".to_string())
@@ -75,7 +78,19 @@ impl IndexEngine {
             state.publish_diagnostics(*id, diags).await;
         }
 
-        let _ = state.client.inlay_hint_refresh().await;
+        if state
+            .client_capabilities
+            .workspace
+            .as_ref()
+            .is_some_and(|w| {
+                w.inlay_hint
+                    .as_ref()
+                    .is_some_and(|i| i.refresh_support.is_some_and(|r| r))
+            })
+        {
+            state.client.inlay_hint_refresh().await.unwrap();
+        }
+
         progress.finish().await;
     }
 }

--- a/lsp/src/index_engine.rs
+++ b/lsp/src/index_engine.rs
@@ -75,7 +75,7 @@ impl IndexEngine {
             state.publish_diagnostics(*id, diags).await;
         }
 
-        state.client.inlay_hint_refresh().await.unwrap();
+        let _ = state.client.inlay_hint_refresh().await;
         progress.finish().await;
     }
 }

--- a/lsp/src/state.rs
+++ b/lsp/src/state.rs
@@ -3,7 +3,8 @@ use codespan::FileId;
 use std::collections::HashMap;
 use std::str::FromStr;
 use tower_lsp_server::lsp_types::{
-    Diagnostic, TextDocumentContentChangeEvent, Uri, VersionedTextDocumentIdentifier,
+    ClientCapabilities, Diagnostic, TextDocumentContentChangeEvent, Uri,
+    VersionedTextDocumentIdentifier,
 };
 use tower_lsp_server::Client;
 
@@ -12,6 +13,7 @@ pub struct State {
     pub files: Files,
     pub workspace_folder: Option<Uri>,
     pub client: Client,
+    pub client_capabilities: ClientCapabilities,
 }
 
 impl State {


### PR DESCRIPTION
(self explanatory commit message)

---

**Describe the bug**
Certain editors are crashing the LSP because it's calling `unwrap()` on the `inlay_hint_refresh()` method call, which I assume they don't support, and as such is returning an error in the result union.

**To Reproduce**
Steps to reproduce the behavior:
1. Open an assembly _project_ (not just a standalone file) in an editor that has the LSP running but _does not_ support `inlay_hint_refresh()` (e.g. helix)
3. LSP should crash within a couple seconds of opening

**Expected behavior**
LSP should index the files in the project like normal

**Screenshots**
(from my `helix.log`)
![Image](https://github.com/user-attachments/assets/45d17e4c-bb8e-4392-b189-d6a6f61bdc13)

**Desktop (please complete the following information):**
 - OS: Windows 11
 - Editor: Helix 25.01.1
